### PR TITLE
fix: wallet_addEthereumChain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainbow-me/provider",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "dist/index.js",
   "license": "MIT",
   "type": "module",

--- a/src/handleProviderRequest.ts
+++ b/src/handleProviderRequest.ts
@@ -277,8 +277,10 @@ export const handleProviderRequest = ({
             }
 
             // PER EIP - return null if the network was added otherwise throw
-            if (response !== null) {
+            if (!response) {
               throw new Error('User rejected the request.');
+            } else {
+              response = null
             }
           }
           break;


### PR DESCRIPTION
https://linear.app/rainbow/issue/BX-1326/switch-chain-error-after-wallet-addethereumchain

in the extension we have a check for a null response from the user approval action to throw the "user rejected request" error https://github.com/rainbow-me/browser-extension/pull/1365/files#diff-2d277810f39350dfb5b9554318cf5abb10da91a46a5837ed108fc543c3b4a6f9L79

since we were always returning null from the messenger this was always throwing https://github.com/rainbow-me/browser-extension/blob/master/src/entries/background/handlers/handleProviderRequest.ts#L128

i'm now sending `true` from the popup so this doesn't throw, and if the response from the messenger is `!response` we're now throwing the error, if not `response` is `null` and we return that per EIP