### PR TITLE
Bump & add prepare command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@rainbow-me/provider",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "main": "dist/index.js",
   "license": "MIT",
   "files": [
     "dist/**/*"
   ],
   "scripts": {
+    "prepare": "yarn build",
     "build": "tsc",
     "test": "./scripts/tests.sh",
     "lint": "eslint --cache --max-warnings 0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainbow-me/provider",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "dist/index.js",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
Added the prepare command so the build runs before publishing.
I didn't know this wasn't set up so I published without building twice (that's why the bump from .7 to .10)