### PR TITLE
make methods wagmi version agnostic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainbow-me/provider",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "main": "dist/index.js",
   "license": "MIT",
   "files": [

--- a/src/handleProviderRequest.test.ts
+++ b/src/handleProviderRequest.test.ts
@@ -71,11 +71,11 @@ describe('handleProviderRequest', () => {
       }
     }
   });
-  const getChainMock = vi.fn((chainId: number) => {
+  const getChainNativeCurrencyMock = vi.fn((chainId: number) => {
     switch (chainId) {
       case 1:
       default:
-        return mainnet;
+        return mainnet.nativeCurrency;
     }
   });
   const getProviderMock = vi.fn(({ chainId }: { chainId?: number }) => {
@@ -145,7 +145,7 @@ describe('handleProviderRequest', () => {
       checkRateLimit: checkRateLimitMock,
       isSupportedChain: isSupportedChainMock,
       getActiveSession: getActiveSessionMock,
-      getChain: getChainMock,
+      getChainNativeCurrency: getChainNativeCurrencyMock,
       getProvider: getProviderMock,
       messengerProviderRequest: messengerProviderRequestMock,
       onAddEthereumChain: onAddEthereumChainMock,

--- a/src/handleProviderRequest.ts
+++ b/src/handleProviderRequest.ts
@@ -7,7 +7,7 @@ import {
 import { deriveChainIdByHostname, getDappHost, isValidUrl } from './utils/apps';
 import { normalizeTransactionResponsePayload } from './utils/ethereum';
 import { recoverPersonalSignature } from '@metamask/eth-sig-util';
-import { AddEthereumChainProposedChain, Chain } from './references/chains';
+import { AddEthereumChainProposedChain } from './references/chains';
 import { Address, isAddress, isHex } from 'viem';
 import {
   CallbackOptions,
@@ -18,6 +18,7 @@ import {
 import { ActiveSession } from './references/appSession';
 import { toHex } from './utils/hex';
 import { errorCodes } from './references/errorCodes';
+import { ChainNativeCurrency } from 'viem/_types/types/chain';
 
 const buildError = ({
   id,
@@ -47,7 +48,7 @@ export const handleProviderRequest = ({
   checkRateLimit,
   isSupportedChain,
   getActiveSession,
-  getChain,
+  getChainNativeCurrency,
   getProvider,
   messengerProviderRequest,
   onAddEthereumChain,
@@ -67,7 +68,7 @@ export const handleProviderRequest = ({
   }) => Promise<{ id: number; error: Error } | undefined>;
   isSupportedChain: (chainId: number) => boolean;
   getActiveSession: ({ host }: { host: string }) => ActiveSession;
-  getChain: (chainId: number) => Chain | undefined;
+  getChainNativeCurrency: (chainId: number) => ChainNativeCurrency | undefined;
   getProvider: (options: { chainId?: number }) => Provider;
   messengerProviderRequest: (
     request: ProviderRequestPayload,
@@ -300,8 +301,10 @@ export const handleProviderRequest = ({
               });
               // Validate symbol against existing chains
             } else if (isSupportedChain?.(Number(chainId))) {
-              const knownChain = getChain(Number(chainId));
-              if (knownChain?.nativeCurrency.symbol !== symbol) {
+              const knownChainNativeCurrency = getChainNativeCurrency(
+                Number(chainId),
+              );
+              if (knownChainNativeCurrency?.symbol !== symbol) {
                 return buildError({
                   id,
                   message: `nativeCurrency.symbol does not match currency symbol for a network the user already has added with the same chainId. Received: ${symbol}`,


### PR DESCRIPTION
`getChain` was requiring a `Chain` object that is different than v2

since we're doing a bump on bx, i'm changing it to `getChainNativeCurrency` which just returns a native currency object that's compatible with v2 and v0