### PR TITLE
Conversion of internal provider handling to Viem PublicClient from Ethers V5

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ethersproject/providers": "5.7.2",
     "@metamask/eth-sig-util": "7.0.1",
     "eventemitter3": "5.0.1",
-    "viem": "1.21.4"
+    "viem": "2.30.6"
   },
   "resolutions": {
     "vite": "5.1.7",

--- a/src/handleProviderRequest.test.ts
+++ b/src/handleProviderRequest.test.ts
@@ -5,9 +5,8 @@ import {
   ProviderRequestPayload,
   RequestResponse,
 } from './references/messengers';
-import { Address, isHex, toHex } from 'viem';
-import { mainnet, optimism } from 'viem/chains';
-import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { Address, createPublicClient, http, isHex, toHex, PublicClient } from 'viem';
+import { mainnet, optimism, hardhat } from 'viem/chains';
 
 const TESTMAR27_ETH_ADDRESS: Address =
   '0x5e087b61aad29559e31565079fcdabe384b44614';
@@ -78,11 +77,13 @@ describe('handleProviderRequest', () => {
         return mainnet.nativeCurrency;
     }
   });
-  const getProviderMock = vi.fn(({ chainId }: { chainId?: number }) => {
+  const getProviderMock = vi.fn(({ chainId }: { chainId?: number }): PublicClient => {
     switch (chainId) {
-      case 1:
       default:
-        return new StaticJsonRpcProvider('http://127.0.0.1:8545');
+        return createPublicClient({
+          chain: hardhat,
+          transport: http(hardhat.rpcUrls.default.http[0]),
+        }) as PublicClient;
     }
   });
   const messengerProviderRequestMock = vi.fn((payload) => {
@@ -483,7 +484,7 @@ describe('handleProviderRequest', () => {
           {
             blockExplorerUrls: [mainnet.blockExplorers.default.url],
             chainId: toHex(mainnet.id),
-            chainName: mainnet.network,
+            chainName: mainnet.name,
             nativeCurrency: mainnet.nativeCurrency,
             rpcUrls: [mainnet.rpcUrls.default.http],
           },
@@ -520,7 +521,7 @@ describe('handleProviderRequest', () => {
       {
         id: 1,
         method: 'wallet_watchAsset',
-        params: {
+        params: [{
           type: 'ERC20',
           options: {
             address: '0xb60e8dd61c5d32be8058bb8eb970870f07233155',
@@ -528,7 +529,7 @@ describe('handleProviderRequest', () => {
             decimals: 18,
             image: 'https://foo.io/token-image.svg',
           },
-        },
+        }],
         meta: {
           sender: { url: 'https://dapp1.com' },
           topic: 'providerRequest',

--- a/src/handleProviderRequest.ts
+++ b/src/handleProviderRequest.ts
@@ -2,7 +2,7 @@ import { deriveChainIdByHostname, getDappHost, isValidUrl } from './utils/apps';
 import { normalizeTransactionResponsePayload } from './utils/ethereum';
 import { recoverPersonalSignature } from '@metamask/eth-sig-util';
 import { AddEthereumChainProposedChain, Chain } from './references/chains';
-import { Address, EIP1474Methods, isAddress, isHex, PublicClient } from 'viem';
+import { Address, isAddress, isHex, PublicClient } from 'viem';
 import {
   CallbackOptions,
   IProviderRequestTransport,

--- a/src/utils/ethereum.test.ts
+++ b/src/utils/ethereum.test.ts
@@ -1,25 +1,30 @@
 import { describe, it, expect, afterAll } from 'vitest';
-import type {
-  TransactionReceipt,
-  TransactionResponse,
-} from '@ethersproject/abstract-provider';
 import { normalizeTransactionResponsePayload } from './ethereum';
-import { BigNumber } from '@ethersproject/bignumber';
+import type { GetTransactionReturnType } from 'viem';
 
 describe('Utils ethereum', () => {
-  const mockTransactionResponse: TransactionResponse = {
-    wait: async () => {
-      return {} as TransactionReceipt;
-    },
-    hash: '',
-    confirmations: 0,
-    from: '',
-    nonce: 0,
-    gasLimit: BigNumber.from(20000),
-    data: '',
-    value: BigNumber.from(1000000000000),
-    chainId: 0,
-  };
+  const mockTransactionResponse: GetTransactionReturnType = {
+    hash: '0x123',
+    blockHash: '0x123',
+    blockNumber: 1000n,
+    type: 'eip1559',
+    typeHex: '0x02',
+    yParity: 0,
+    input: '0x123',
+    r: '0x123',
+    s: '0x123',
+    v: 0n,
+    accessList: [],
+    maxFeePerGas: 1000000000000n,
+    maxPriorityFeePerGas: 1000000000000n,
+    transactionIndex: 0,
+    from: '0x456',
+    to: '0x789',
+    value: 1000000000000n,
+    gas: 20000n,
+    nonce: 100,
+    chainId: 1,
+  }
 
   it('removes wait function on Firefox', () => {
     Object.defineProperty(window.navigator, 'userAgent', {

--- a/src/utils/ethereum.ts
+++ b/src/utils/ethereum.ts
@@ -1,13 +1,46 @@
+import type { GetTransactionReturnType } from 'viem';
+import { bigIntToBigNumber } from './hex';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 
+
 export const normalizeTransactionResponsePayload = (
-  payload: TransactionResponse,
+  payload: GetTransactionReturnType,
 ): TransactionResponse => {
   // Firefox can't serialize functions
   if (navigator.userAgent?.toLowerCase().includes('firefox')) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { wait: _, ...cleanedPayload } = payload;
+    const { wait: _, ...cleanedPayload } = viemTransactionToEthersResponse(payload);
     return cleanedPayload as TransactionResponse;
   }
-  return payload;
+  return viemTransactionToEthersResponse(payload);
+};
+
+// Convert Viem transaction to our ViemTransactionResponse
+export const viemTransactionToEthersResponse = (
+  viemTx: GetTransactionReturnType
+): TransactionResponse => {
+  return {
+    hash: viemTx.hash,
+    blockHash: viemTx.blockHash || undefined,
+    blockNumber: viemTx.blockNumber ? Number(viemTx.blockNumber) : undefined,
+    confirmations: 0, // Will be populated by provider if needed
+    from: viemTx.from,
+    gasPrice: viemTx.gasPrice ? bigIntToBigNumber(viemTx.gasPrice) : undefined,
+    maxFeePerGas: viemTx.maxFeePerGas ? bigIntToBigNumber(viemTx.maxFeePerGas) : undefined,
+    maxPriorityFeePerGas: viemTx.maxPriorityFeePerGas ? bigIntToBigNumber(viemTx.maxPriorityFeePerGas) : undefined,
+    gasLimit: bigIntToBigNumber(viemTx.gas),
+    to: viemTx.to || undefined,
+    value: bigIntToBigNumber(viemTx.value),
+    nonce: Number(viemTx.nonce),
+    data: viemTx.input,
+    r: viemTx.r || undefined,
+    s: viemTx.s || undefined,
+    v: viemTx.v ? Number(viemTx.v) : undefined,
+    chainId: viemTx.chainId ? Number(viemTx.chainId) : 0,
+    type: viemTx.type === 'legacy' ? 0 : viemTx.type === 'eip2930' ? 1 : viemTx.type === 'eip1559' ? 2 : undefined,
+    // Note: wait function will be handled in normalizeTransactionResponsePayload
+    wait: async () => {
+      throw new Error('Transaction wait not implemented for Viem transactions');
+    },
+  };
 };

--- a/src/utils/hex.test.ts
+++ b/src/utils/hex.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { BigNumber } from '@ethersproject/bignumber';
-import { toHex } from './hex';
+import { bigIntToBigNumber, bigNumberToBigInt, toHex } from './hex';
 
 describe('Utils hex', () => {
   it('converts a number to a hex string', () => {
@@ -19,5 +19,23 @@ describe('Utils hex', () => {
     const bigNumberInput = BigNumber.from(789);
     const expectedHex = '0x315';
     expect(toHex(bigNumberInput)).toBe(expectedHex);
+  });
+
+  it('converts a BigInt to a hex string', () => {
+    const bigIntInput = 789n;
+    const expectedHex = '0x315';
+    expect(toHex(bigIntInput)).toBe(expectedHex);
+  });
+
+  it('converts a BigInt to a BigNumber', () => {
+    const bigIntInput = 789n;
+    const expectedBigNumber = BigNumber.from(789);
+    expect(bigIntToBigNumber(bigIntInput)).toStrictEqual(expectedBigNumber);
+  });
+
+  it('converts a BigNumber to a BigInt', () => {
+    const bigNumberInput = BigNumber.from(789);
+    const expectedBigInt = 789n;
+    expect(bigNumberToBigInt(bigNumberInput)).toBe(expectedBigInt);
   });
 });

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -1,6 +1,23 @@
 import { BigNumber } from '@ethersproject/bignumber';
+import { toHex as viemToHex } from 'viem';
 import { hexValue } from '@ethersproject/bytes';
 
-export const toHex = (stringToConvert: string | number | BigNumber): string => {
+export const toHex = (stringToConvert: string | number | BigNumber | bigint): string => {
+  // Handle BigInt from Viem
+  if (typeof stringToConvert === 'bigint') {
+    return viemToHex(stringToConvert);
+  }
+  
+  // Handle existing BigNumber/string/number types
   return hexValue(BigNumber.from(stringToConvert).toHexString());
+};
+
+// Helper function to convert BigInt to BigNumber for backward compatibility
+export const bigIntToBigNumber = (value: bigint): BigNumber => {
+  return BigNumber.from(value.toString());
+};
+
+// Helper function to convert BigNumber to BigInt for Viem compatibility
+export const bigNumberToBigInt = (value: BigNumber): bigint => {
+  return BigInt(value.toString());
 };

--- a/src/utils/rpcTypes.ts
+++ b/src/utils/rpcTypes.ts
@@ -1,0 +1,112 @@
+import type { Hex, Address, BlockTag } from 'viem';
+import type { TransactionRequest } from 'viem';
+import type { AddEthereumChainProposedChain } from '../references/chains';
+
+// Interface for wallet permissions params
+interface WalletPermissionsParams {
+  eth_accounts: object;
+}
+
+// Interface for watch asset params
+interface WatchAssetParams {
+  type: 'ERC20';
+  options: {
+    address: Address;
+    symbol?: string;
+    decimals?: number;
+  };
+}
+
+// Interface for switch chain params
+interface SwitchChainParams {
+  chainId: string;
+}
+
+// Discriminated union type for RPC method requests
+export type RPCMethodRequest = 
+  // Methods with no parameters
+  | { method: 'eth_chainId'; params?: never }
+  | { method: 'eth_coinbase'; params?: never }
+  | { method: 'eth_accounts'; params?: never }
+  | { method: 'eth_blockNumber'; params?: never }
+  | { method: 'eth_gasPrice'; params?: never }
+  | { method: 'eth_requestAccounts'; params?: never }
+  
+  // Methods with single address parameter
+  | { method: 'eth_getBalance'; params: [Address] }
+  | { method: 'eth_getTransactionByHash'; params: [Hex] }
+  
+  // Methods with address and optional block tag
+  | { method: 'eth_getCode'; params: [Address, BlockTag?] }
+  
+  // Methods with transaction request
+  | { method: 'eth_call'; params: [TransactionRequest] }
+  | { method: 'eth_estimateGas'; params: [TransactionRequest] }
+  | { method: 'eth_sendTransaction'; params: [TransactionRequest] }
+  | { method: 'eth_signTransaction'; params: [TransactionRequest] }
+  
+  // Signing methods with message and address
+  | { method: 'personal_sign'; params: [string, Address] }
+  | { method: 'personal_ecRecover'; params: [string, string] }
+  
+  // Typed data signing methods (address can be first or second param)
+  | { method: 'eth_signTypedData'; params: [Address, any] | [any, Address] }
+  | { method: 'eth_signTypedData_v3'; params: [Address, any] | [any, Address] }
+  | { method: 'eth_signTypedData_v4'; params: [Address, any] | [any, Address] }
+  
+  // Wallet methods
+  | { method: 'wallet_addEthereumChain'; params: [AddEthereumChainProposedChain] }
+  | { method: 'wallet_switchEthereumChain'; params: [SwitchChainParams] }
+  | { method: 'wallet_watchAsset'; params: [WatchAssetParams] }
+  | { method: 'wallet_revokePermissions'; params: [WalletPermissionsParams] }
+  
+  // Generic fallback for unknown methods
+  | { method: string; params?: unknown[] };
+
+// Helper type to extract parameters for a specific method
+export type ParamsForMethod<T extends RPCMethodRequest['method']> = 
+  Extract<RPCMethodRequest, { method: T }>['params'];
+
+// Type-safe parameter extractors for each method
+export function getBalanceParams(params: unknown[]): [Address] {
+  return [params[0] as Address];
+}
+
+export function getTransactionByHashParams(params: unknown[]): [Hex] {
+  return [params[0] as Hex];
+}
+
+export function getCodeParams(params: unknown[]): [Address, BlockTag?] {
+  return [params[0] as Address, params[1] as BlockTag];
+}
+
+export function getCallParams(params: unknown[]): [TransactionRequest] {
+  return [params[0] as TransactionRequest];
+}
+
+export function getEstimateGasParams(params: unknown[]): [TransactionRequest] {
+  return [params[0] as TransactionRequest];
+}
+
+export function getSigningParams(params: unknown[]): [string, string] {
+  return [params[0] as string, params[1] as string];
+}
+
+export function getAddChainParams(params: unknown[]): [AddEthereumChainProposedChain] {
+  return [params[0] as AddEthereumChainProposedChain];
+}
+
+export function getSwitchChainParams(params: unknown[]): [SwitchChainParams] {
+  return [params[0] as SwitchChainParams];
+}
+
+export function getWatchAssetParams(params: unknown[]): [WatchAssetParams] {
+  return [params[0] as WatchAssetParams];
+}
+
+export function getRevokePermissionsParams(params: unknown[]): [WalletPermissionsParams] {
+  return [params[0] as WalletPermissionsParams];
+}
+
+// Export the interfaces for use in other files
+export type { WalletPermissionsParams, WatchAssetParams, SwitchChainParams }; 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@adraffy/ens-normalize@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz#d2a39395c587e092d77cbbc80acf956a54f38bf7"
-  integrity sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==
+"@adraffy/ens-normalize@^1.10.1":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz#42cc67c5baa407ac25059fcd7d405cc5ecdb0c33"
+  integrity sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==
 
 "@esbuild/aix-ppc64@0.19.12":
   version "0.19.12"
@@ -469,12 +469,10 @@
     semver "^7.5.4"
     superstruct "^1.0.3"
 
-"@noble/curves@1.2.0", "@noble/curves@~1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
-  integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
-  dependencies:
-    "@noble/hashes" "1.3.2"
+"@noble/ciphers@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-1.3.0.tgz#f64b8ff886c240e644e5573c097f86e5b43676dc"
+  integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
 
 "@noble/curves@1.3.0", "@noble/curves@~1.3.0":
   version "1.3.0"
@@ -483,15 +481,22 @@
   dependencies:
     "@noble/hashes" "1.3.3"
 
-"@noble/hashes@1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
-  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
+"@noble/curves@1.9.1", "@noble/curves@^1.6.0", "@noble/curves@~1.9.0":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.1.tgz#9654a0bc6c13420ae252ddcf975eaf0f58f0a35c"
+  integrity sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==
+  dependencies:
+    "@noble/hashes" "1.8.0"
 
-"@noble/hashes@1.3.3", "@noble/hashes@^1.3.1", "@noble/hashes@~1.3.0", "@noble/hashes@~1.3.2":
+"@noble/hashes@1.3.3", "@noble/hashes@^1.3.1", "@noble/hashes@~1.3.2":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
   integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
+
+"@noble/hashes@1.8.0", "@noble/hashes@^1.5.0", "@noble/hashes@~1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -584,19 +589,15 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.0.tgz#9ffdf9ed133a7464f4ae187eb9e1294413fab235"
   integrity sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==
 
-"@scure/base@^1.1.3", "@scure/base@~1.1.0", "@scure/base@~1.1.2", "@scure/base@~1.1.4":
+"@scure/base@^1.1.3", "@scure/base@~1.1.4":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.5.tgz#1d85d17269fe97694b9c592552dd9e5e33552157"
   integrity sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==
 
-"@scure/bip32@1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.3.2.tgz#90e78c027d5e30f0b22c1f8d50ff12f3fb7559f8"
-  integrity sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==
-  dependencies:
-    "@noble/curves" "~1.2.0"
-    "@noble/hashes" "~1.3.2"
-    "@scure/base" "~1.1.2"
+"@scure/base@~1.2.5":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
+  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
 
 "@scure/bip32@1.3.3":
   version "1.3.3"
@@ -607,13 +608,14 @@
     "@noble/hashes" "~1.3.2"
     "@scure/base" "~1.1.4"
 
-"@scure/bip39@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.2.1.tgz#5cee8978656b272a917b7871c981e0541ad6ac2a"
-  integrity sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==
+"@scure/bip32@1.7.0", "@scure/bip32@^1.5.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.7.0.tgz#b8683bab172369f988f1589640e53c4606984219"
+  integrity sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==
   dependencies:
-    "@noble/hashes" "~1.3.0"
-    "@scure/base" "~1.1.0"
+    "@noble/curves" "~1.9.0"
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
 
 "@scure/bip39@1.2.2":
   version "1.2.2"
@@ -622,6 +624,14 @@
   dependencies:
     "@noble/hashes" "~1.3.2"
     "@scure/base" "~1.1.4"
+
+"@scure/bip39@1.6.0", "@scure/bip39@^1.4.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.6.0.tgz#475970ace440d7be87a6086cbee77cb8f1a684f9"
+  integrity sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==
+  dependencies:
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -798,10 +808,10 @@ JSONStream@^1.3.5:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-abitype@0.9.8:
-  version "0.9.8"
-  resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.9.8.tgz#1f120b6b717459deafd213dfbf3a3dd1bf10ae8c"
-  integrity sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==
+abitype@1.0.8, abitype@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.8.tgz#3554f28b2e9d6e9f35eb59878193eabd1b9f46ba"
+  integrity sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -1599,10 +1609,10 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-isows@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.3.tgz#93c1cf0575daf56e7120bab5c8c448b0809d0d74"
-  integrity sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==
+isows@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.7.tgz#1c06400b7eed216fbba3bcbd68f12490fc342915"
+  integrity sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==
 
 jju@^1.4.0:
   version "1.4.0"
@@ -1865,6 +1875,20 @@ optionator@^0.9.3:
     levn "^0.4.1"
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
+
+ox@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.7.1.tgz#fb23a770dd966c051ad916d4e2e655a6f995e1cf"
+  integrity sha512-+k9fY9PRNuAMHRFIUbiK9Nt5seYHHzSQs9Bj+iMETcGtlpS7SmBzcGSVUQO3+nqGLEiNK4598pHNFlVRaZbRsg==
+  dependencies:
+    "@adraffy/ens-normalize" "^1.10.1"
+    "@noble/ciphers" "^1.3.0"
+    "@noble/curves" "^1.6.0"
+    "@noble/hashes" "^1.5.0"
+    "@scure/bip32" "^1.5.0"
+    "@scure/bip39" "^1.4.0"
+    abitype "^1.0.6"
+    eventemitter3 "5.0.1"
 
 p-limit@^3.0.2:
   version "3.1.0"
@@ -2350,19 +2374,19 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-viem@1.21.4:
-  version "1.21.4"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-1.21.4.tgz#883760e9222540a5a7e0339809202b45fe6a842d"
-  integrity sha512-BNVYdSaUjeS2zKQgPs+49e5JKocfo60Ib2yiXOWBT6LuVxY1I/6fFX3waEtpXvL1Xn4qu+BVitVtMh9lyThyhQ==
+viem@2.30.6:
+  version "2.30.6"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.30.6.tgz#fffe69aa4d16ab1802b21b44856ae09bacf10f9b"
+  integrity sha512-N3vGy3pZ+EVgQRuWqQhZPFXxQE8qMRrBd3uM+KLc1Ub2w6+vkyr7umeWQCM4c+wlsCdByUgh2630MDMLquMtpg==
   dependencies:
-    "@adraffy/ens-normalize" "1.10.0"
-    "@noble/curves" "1.2.0"
-    "@noble/hashes" "1.3.2"
-    "@scure/bip32" "1.3.2"
-    "@scure/bip39" "1.2.1"
-    abitype "0.9.8"
-    isows "1.0.3"
-    ws "8.13.0"
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "1.8.0"
+    "@scure/bip32" "1.7.0"
+    "@scure/bip39" "1.6.0"
+    abitype "1.0.8"
+    isows "1.0.7"
+    ox "0.7.1"
+    ws "8.18.2"
 
 vite-node@1.6.0:
   version "1.6.0"
@@ -2478,10 +2502,10 @@ ws@7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
-ws@8.13.0:
-  version "8.13.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
-  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
+ws@8.18.2:
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.2.tgz#42738b2be57ced85f46154320aabb51ab003705a"
+  integrity sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==
 
 ws@^8.16.0:
   version "8.16.0"


### PR DESCRIPTION
Fixes APP-2713

Converts internal handling of provider functions to Viem PublicClient instead of StaticJsonRpcProvider. 
<img width="1340" alt="Screenshot 2025-06-03 at 4 38 33 PM" src="https://github.com/user-attachments/assets/03a88952-87ac-4669-af52-2682ca2d3767" />
