### PR TITLE
chore: github tag, release automation

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
     "anvil": "ETH_MAINNET_RPC=$(grep ETH_MAINNET_RPC .env | cut -d '=' -f2) && anvil --fork-url $ETH_MAINNET_RPC",
     "anvil:kill": "lsof -i :8545|tail -n +2|awk '{print $2}'|xargs -r kill -s SIGINT",
     "changeset": "changeset",
-    "release": "yarn release:verify-git && yarn build && changeset publish --tag latest",
-    "release:verify-git": "git diff --exit-code && git rev-parse --abbrev-ref HEAD | grep \"main\""
+    "release": "yarn release:verify-git && yarn release:publish && yarn release:github",
+    "release:verify-git": "git diff --exit-code && git rev-parse --abbrev-ref HEAD | grep -q main",
+    "release:publish": "changeset publish --tag latest && git push --follow-tags",
+    "release:github": "TAG=$(git describe --tags --abbrev=0) && awk '/^## /{if(p++)exit;next}p' CHANGELOG.md | gh release create \"$TAG\" --notes-file -"
   },
   "module": "dist/index.js",
   "devDependencies": {


### PR DESCRIPTION
This PR enhances the release process by breaking it down into three distinct steps:

1. Adds a new `release:publish` script that publishes the changeset with the latest tag and pushes git tags
2. Adds a `release:github` script that automatically creates a GitHub release using the latest tag and content from the CHANGELOG.md
3. Updates the main `release` script to orchestrate these new steps in sequence

The PR also improves the git branch verification by using the `-q` flag for quieter output when checking for the main branch.